### PR TITLE
Remove circle collision

### DIFF
--- a/src/cleanup.rs
+++ b/src/cleanup.rs
@@ -24,7 +24,7 @@ pub fn reset_initial_state(
     if let Ok((mut text, _)) = current_wave_ui.get_single_mut() {
         text.sections.first_mut().unwrap().value = format!("Wave #{}", current_wave.0);
     }
-    current_time.minutes = 10u16;
+    current_time.minutes = 0u16;
     current_time.seconds = 30u16;
     current_score.0 = 0.0;
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -714,7 +714,7 @@ pub fn expand_circle_of_death(
         let new_outer_radius = circle.outer_circle_radius * 0.2 + circle.outer_circle_radius;
         let new_inner_radius = new_outer_radius - 10.0;
 
-        if new_inner_radius > BACKGROUND_TEXTURE_RESOLUTION.x_px {
+        if new_inner_radius > BACKGROUND_TEXTURE_SCALE * BACKGROUND_TEXTURE_RESOLUTION.x_px {
             commands.entity(circle_entity).despawn();
             commands.trigger(DespawnPower(PowerTypeEnum::CircleOfDeath));
             continue;

--- a/src/game_actions.rs
+++ b/src/game_actions.rs
@@ -343,6 +343,8 @@ pub fn power_up(
     mut player_query: Query<(Entity, &mut Mana, &Children, &Transform)>,
     power_query: Query<(&Damage, &Power)>,
     base_camera: Query<(&Transform, &BaseCamera), Without<Player>>,
+
+    enemies: Query<(Entity, &mut Health, &Damage), With<Enemy>>,
 ) {
     let Ok((base_camera_transform, _)) = base_camera.get_single() else {
         return;
@@ -395,6 +397,7 @@ pub fn power_up(
             power.clone(),
             power_damage.clone(),
             player_translation,
+            enemies,
         );
         Some(power.mana_needed)
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,7 +154,7 @@ fn main() {
                 remove_outdated_buffs.run_if(on_timer(Duration::from_secs(1))),
                 animate_player_buffs.run_if(on_timer(Duration::from_nanos(100))),
                 refill_mana.run_if(on_timer(Duration::from_secs(1))),
-                expand_circle_of_death.run_if(on_timer(Duration::from_millis(100))),
+                expand_circle_of_death.run_if(on_timer(Duration::from_millis(50))),
                 change_enemy_direction.run_if(on_timer(Duration::from_secs(5))),
             )
                 .in_set(TimeBasedSet),

--- a/todo.wiki
+++ b/todo.wiki
@@ -77,6 +77,9 @@ as the time passes (cooldown)
 - [x] Create an item that will give the player HP
 - [x] Improve enemy movement towards player
 - [x] (RELATED) Create a way of enemies not getting too much together
+- [x] (BUG) Circle is just killing all enemies.
+- [ ] (BUG kinda) Remember to generate meta assets for the energy pack before 
+		pushing to Itchio.
 - [ ] Weapons spawned are too small
 
 Ongoing:


### PR DESCRIPTION
As the circle does a pass on the whole screen,
it will always deal damage to ALL enemies.
Therefore, there is no need to check for collisions.